### PR TITLE
Preserve significant figures in HdrHistogram logging

### DIFF
--- a/eb-api/src/main/java/io/engineblock/metrics/ActivityMetrics.java
+++ b/eb-api/src/main/java/io/engineblock/metrics/ActivityMetrics.java
@@ -99,7 +99,7 @@ public class ActivityMetrics {
     public static Timer timer(ActivityDef activityDef, String name) {
         String fullMetricName = activityDef.getAlias() + "." + name;
         Timer registeredTimer = (Timer) register(activityDef, name, () ->
-                new NicerTimer(fullMetricName, new DeltaHdrHistogramReservoir(fullMetricName, new Recorder(4))));
+                new NicerTimer(fullMetricName, new DeltaHdrHistogramReservoir(fullMetricName, 4)));
         return registeredTimer;
     }
 
@@ -115,7 +115,7 @@ public class ActivityMetrics {
     public static Histogram histogram(ActivityDef activityDef, String name) {
         String fullMetricName = activityDef.getAlias() + "." + name;
         return (Histogram) register(activityDef, name, () ->
-                new NicerHistogram(fullMetricName, new DeltaHdrHistogramReservoir(fullMetricName, new Recorder(4))));
+                new NicerHistogram(fullMetricName, new DeltaHdrHistogramReservoir(fullMetricName, 4)));
     }
 
     /**

--- a/eb-api/src/main/java/io/engineblock/metrics/DeltaHdrHistogramReservoir.java
+++ b/eb-api/src/main/java/io/engineblock/metrics/DeltaHdrHistogramReservoir.java
@@ -36,32 +36,22 @@ public final class DeltaHdrHistogramReservoir implements Reservoir {
 
     private final Recorder recorder;
     private Histogram lastHistogram;
-    private int signifantDigits;
+    private final int significantDigits;
 
     private Histogram intervalHistogram;
     private long intervalHistogramEndTime = System.currentTimeMillis();
-    private String metricName;
+    private final String metricName;
 
     /**
      * Create a reservoir with a default recorder. This recorder should be suitable for most usage.
      *
      * @param name the name to give to the reservoir, for logging purposes
-     * @param signifantDigits how many significant digits to track in the reservoir
+     * @param significantDigits how many significant digits to track in the reservoir
      */
-    public DeltaHdrHistogramReservoir(String name, int signifantDigits) {
-        this(name, new Recorder(signifantDigits));
-        this.signifantDigits = signifantDigits;
-    }
-
-    /**
-     * Create a reservoir with a user-specified recorder.
-     *
-     * @param name the name to give to the reservoir for logging purposes
-     * @param recorder Recorder to use
-     */
-    public DeltaHdrHistogramReservoir(String name, Recorder recorder) {
+    public DeltaHdrHistogramReservoir(String name, int significantDigits) {
         this.metricName = name;
-        this.recorder = recorder;
+        this.recorder = new Recorder(significantDigits);
+        this.significantDigits = significantDigits;
 
         /*
          * Start by flipping the recorder's interval histogram.
@@ -91,8 +81,7 @@ public final class DeltaHdrHistogramReservoir implements Reservoir {
     @Override
     public Snapshot getSnapshot() {
         lastHistogram = getNextHdrHistogram();
-        DeltaHistogramSnapshot snapshot = new DeltaHistogramSnapshot(lastHistogram);
-        return snapshot;
+        return new DeltaHistogramSnapshot(lastHistogram);
     }
 
     public Histogram getNextHdrHistogram() {
@@ -134,6 +123,6 @@ public final class DeltaHdrHistogramReservoir implements Reservoir {
     }
 
     public DeltaHdrHistogramReservoir copySettings() {
-        return new DeltaHdrHistogramReservoir(this.metricName, new Recorder(signifantDigits));
+        return new DeltaHdrHistogramReservoir(this.metricName, significantDigits);
     }
 }

--- a/eb-api/src/main/java/io/engineblock/metrics/DeltaHdrHistogramReservoir.java
+++ b/eb-api/src/main/java/io/engineblock/metrics/DeltaHdrHistogramReservoir.java
@@ -30,10 +30,6 @@ import org.slf4j.LoggerFactory;
  * since it was most recently asked for with the getDeltaSnapshot(...) method.
  * This provides local snapshot timing, but with a consistent view for reporting channels about what those snapshots
  * most recently looked like.
- *
- * <p>This implementation also supports attaching a single log writer. If a log writer is attached, each
- * time an interval is snapshotted internally, the data will also be written to an hdr log via the writer.</p>
- *
  */
 public final class DeltaHdrHistogramReservoir implements Reservoir {
     private final static Logger logger = LoggerFactory.getLogger(DeltaHdrHistogramReservoir.class);
@@ -45,7 +41,6 @@ public final class DeltaHdrHistogramReservoir implements Reservoir {
     private Histogram intervalHistogram;
     private long intervalHistogramEndTime = System.currentTimeMillis();
     private String metricName;
-    private HistogramLogWriter writer;
 
     /**
      * Create a reservoir with a default recorder. This recorder should be suitable for most usage.
@@ -127,9 +122,6 @@ public final class DeltaHdrHistogramReservoir implements Reservoir {
         lastHistogram = intervalHistogram.copy();
         lastHistogram.setTag(metricName);
 
-        if (writer!=null) {
-            writer.outputIntervalHistogram(lastHistogram);
-        }
         return lastHistogram;
     }
 
@@ -143,13 +135,5 @@ public final class DeltaHdrHistogramReservoir implements Reservoir {
 
     public DeltaHdrHistogramReservoir copySettings() {
         return new DeltaHdrHistogramReservoir(this.metricName, new Recorder(signifantDigits));
-    }
-
-    public void attachLogWriter(HistogramLogWriter logWriter) {
-        this.writer = logWriter;
-    }
-
-    public Histogram getLastHistogram() {
-        return lastHistogram;
     }
 }

--- a/eb-api/src/main/java/io/engineblock/metrics/DeltaHdrHistogramReservoir.java
+++ b/eb-api/src/main/java/io/engineblock/metrics/DeltaHdrHistogramReservoir.java
@@ -36,7 +36,6 @@ public final class DeltaHdrHistogramReservoir implements Reservoir {
 
     private final Recorder recorder;
     private Histogram lastHistogram;
-    private final int significantDigits;
 
     private Histogram intervalHistogram;
     private long intervalHistogramEndTime = System.currentTimeMillis();
@@ -51,7 +50,6 @@ public final class DeltaHdrHistogramReservoir implements Reservoir {
     public DeltaHdrHistogramReservoir(String name, int significantDigits) {
         this.metricName = name;
         this.recorder = new Recorder(significantDigits);
-        this.significantDigits = significantDigits;
 
         /*
          * Start by flipping the recorder's interval histogram.
@@ -123,6 +121,6 @@ public final class DeltaHdrHistogramReservoir implements Reservoir {
     }
 
     public DeltaHdrHistogramReservoir copySettings() {
-        return new DeltaHdrHistogramReservoir(this.metricName, significantDigits);
+        return new DeltaHdrHistogramReservoir(this.metricName, intervalHistogram.getNumberOfSignificantValueDigits());
     }
 }

--- a/eb-api/src/main/java/io/engineblock/metrics/PeriodicRunnable.java
+++ b/eb-api/src/main/java/io/engineblock/metrics/PeriodicRunnable.java
@@ -17,18 +17,20 @@
 
 package io.engineblock.metrics;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * This is a simple and light way to run a periodic task run
  */
-public class PeriodicRunnable<T extends Runnable> implements Runnable {
+public class PeriodicRunnable<T extends Runnable> implements Runnable, AutoCloseable {
     private static Logger logger = LoggerFactory.getLogger(PeriodicRunnable.class);
 
     private long intervalMillis;
     private T action;
     private Thread thread;
+    private volatile boolean running = false;
 
     public PeriodicRunnable(long intervalMillis, T action) {
         this.action = action;
@@ -43,7 +45,14 @@ public class PeriodicRunnable<T extends Runnable> implements Runnable {
         return this;
     }
 
-    public synchronized  PeriodicRunnable<T> startMainThread() {
+    @Override
+    public synchronized void close()
+    {
+        running = false;
+        Uninterruptibles.joinUninterruptibly(thread);
+    }
+
+    public synchronized PeriodicRunnable<T> startMainThread() {
         thread = new Thread(this);
         thread.setName(action.toString());
         thread.start();
@@ -56,8 +65,9 @@ public class PeriodicRunnable<T extends Runnable> implements Runnable {
 
     @Override
     public void run() {
+        running = true;
         long nextEventTime = System.currentTimeMillis() + intervalMillis;
-        while (true) {
+        while (running) {
             nextEventTime = awaitTime(intervalMillis, nextEventTime);
             logger.trace("invoking interval runnable " + action);
             action.run();

--- a/eb-api/src/test/java/io/engineblock/metrics/HistoIntervalLoggerTest.java
+++ b/eb-api/src/test/java/io/engineblock/metrics/HistoIntervalLoggerTest.java
@@ -42,7 +42,7 @@ public class HistoIntervalLoggerTest {
         HistoIntervalLogger hil = new HistoIntervalLogger("loggertest", tempFile, Pattern.compile(".*"), 1000);
 
         NicerHistogram nicerHistogram = new NicerHistogram(
-                "histo1", new DeltaHdrHistogramReservoir("histo1", new Recorder(4)));
+                "histo1", new DeltaHdrHistogramReservoir("histo1", 4));
 
         hil.onHistogramAdded("histo1",nicerHistogram);
 

--- a/eb-api/src/test/java/io/engineblock/metrics/HistoIntervalLoggerTest.java
+++ b/eb-api/src/test/java/io/engineblock/metrics/HistoIntervalLoggerTest.java
@@ -61,6 +61,8 @@ public class HistoIntervalLoggerTest {
         hil.onHistogramRemoved("histo1");
         moments.add(System.currentTimeMillis()); // 6
 
+        hil.closeMetrics();
+
         HistogramLogReader hlr = new HistogramLogReader(tempFile.getAbsolutePath());
         List<EncodableHistogram> histos = new ArrayList<>();
         EncodableHistogram histogram;


### PR DESCRIPTION
I noticed that the the histograms in hdr logs had 0 significant digits of precision, even though they're supposed to have 4.  Commit ffbd433 fixes the problem, and the other commits do some minor tidying; in particular, 674afa8 fixes an issue with Travis CI failing (it ensures we don't try to read an HdrHistogramLog file before we've closed it).