### PR TITLE
make TargetRateInput support ProgressIndicator

### DIFF
--- a/eb-api/src/main/java/io/engineblock/activityimpl/input/ProgressCapable.java
+++ b/eb-api/src/main/java/io/engineblock/activityimpl/input/ProgressCapable.java
@@ -22,4 +22,5 @@ package io.engineblock.activityimpl.input;
  */
 public interface ProgressCapable {
     double getProgress();
+    double getTotal();
 }

--- a/eb-api/src/main/java/io/engineblock/activityimpl/input/TargetRateInput.java
+++ b/eb-api/src/main/java/io/engineblock/activityimpl/input/TargetRateInput.java
@@ -46,7 +46,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * after the max value. They simply expose it to callers. It is up to the
  * caller to check the value to determine when the input is deemed "used up."</p>
  */
-public class TargetRateInput implements Input, ActivityDefObserver, RateLimiterProvider {
+public class TargetRateInput implements Input, ActivityDefObserver, RateLimiterProvider, ProgressCapable {
     private final static Logger logger = LoggerFactory.getLogger(TargetRateInput.class);
 
     private final AtomicLong cycleValue = new AtomicLong(0L);
@@ -76,6 +76,18 @@ public class TargetRateInput implements Input, ActivityDefObserver, RateLimiterP
                 return new InputInterval.Segment(current,next);
             }
         }
+    }
+
+    @Override
+    public double getProgress()
+    {
+        return (double) (cycleValue.get() - min.get());
+    }
+
+    @Override
+    public double getTotal()
+    {
+        return (double) (max.get() - min.get());
     }
 
     @Override

--- a/eb-core/src/main/java/io/engineblock/activitycore/ProgressIndicator.java
+++ b/eb-core/src/main/java/io/engineblock/activitycore/ProgressIndicator.java
@@ -75,8 +75,7 @@ public class ProgressIndicator implements Runnable {
     public void run() {
         Collection<ProgressMeter> progressMeters = sc.getProgressMeters();
         for (ProgressMeter meter : progressMeters) {
-            String progress = meter.getProgressName() + ": " +
-                    String.format(Locale.US, "%s%%", formatProgress(meter.getProgress())) + "/" + meter.getProgressState();
+            String progress = meter.getProgressName() + ": " + formatProgress(meter.getProgress()) + "/" + meter.getProgressState();
             switch (indicatorMode) {
                 case console:
                     System.out.println(progress);

--- a/eb-core/src/main/java/io/engineblock/core/ActivityExecutor.java
+++ b/eb-core/src/main/java/io/engineblock/core/ActivityExecutor.java
@@ -418,19 +418,21 @@ public class ActivityExecutor implements ParameterMap.Listener, ProgressMeter {
         double totalCycles = endCycle - startCycle;
 
         double total = 0.0D;
+        double progress = 0.0D;
 
-        double progress=0.0D;
         for (Input input : inputs) {
             if (input instanceof ProgressCapable) {
-                double ip = ((ProgressCapable)input).getProgress();
-                progress+=ip;
+                ProgressCapable progressInput = (ProgressCapable) input;
+                total += progressInput.getTotal();
+                progress += progressInput.getProgress();
+
             } else {
+                logger.warn("input does not support activity progress: " + input);
                 return Double.NaN;
             }
         }
 
-        long inputCount = inputs.stream().distinct().count();
-        return progress / (double) inputCount;
+        return progress / total;
     }
 
     @Override


### PR DESCRIPTION
example run:
```
17:14:07.883 [scenarios:001] INFO  i.e.a.input.TargetRateInput - targetrate was set to:30000.0
17:14:08.692 [scenarios:001] INFO  io.engineblock.script.Scenario - Awaiting completion of scenario for 1471228928 millis.
17:14:08.692 [scenarios:001] INFO  io.engineblock.core.ActivityExecutor - Stopping executor for testverify when work completes.
17:14:10.996 [ProgressIndicator/logonly:10s] INFO  i.e.activitycore.ProgressIndicator - testverify: 15.84%/Running
17:14:20.984 [ProgressIndicator/logonly:10s] INFO  i.e.activitycore.ProgressIndicator - testverify: 49.37%/Running
17:14:30.984 [ProgressIndicator/logonly:10s] INFO  i.e.activitycore.ProgressIndicator - testverify: 83.41%/Running
17:14:40.650 [main] INFO  i.e.script.ScenariosExecutor - scenarios executor shutdownActivity after 39653ms.
```