### PR TITLE
Basic Chart Reporter for EB

### DIFF
--- a/eb-api/pom.xml
+++ b/eb-api/pom.xml
@@ -60,6 +60,11 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.19</version>
         </dependency>
+        <dependency>
+            <groupId>com.mitchtalmadge</groupId>
+            <artifactId>ascii-data</artifactId>
+            <version>1.2.0</version>
+        </dependency>
 
         <!-- test scope only -->
 

--- a/eb-api/src/main/java/io/engineblock/metrics/ChartReporter.java
+++ b/eb-api/src/main/java/io/engineblock/metrics/ChartReporter.java
@@ -50,7 +50,7 @@ public class ChartReporter extends ScheduledReporter {
 
     public void generateChart(){
         for (Map.Entry<String, ArrayList<Double>> p99KV : p99sOverTime.entrySet()) {
-            System.out.println(String.format("Charting p99 Latencies (in microseconds) for %s:",p99KV.getKey()));
+            System.out.println(String.format("Charting p99 Latencies (in microseconds) over time (one second intervals) for %s:",p99KV.getKey()));
             double[] p99s = p99KV.getValue().stream().mapToDouble(Double::doubleValue).toArray(); //via method reference
             System.out.println(ASCIIGraph
                     .fromSeries(p99s)

--- a/eb-api/src/main/java/io/engineblock/metrics/ChartReporter.java
+++ b/eb-api/src/main/java/io/engineblock/metrics/ChartReporter.java
@@ -1,0 +1,61 @@
+package io.engineblock.metrics;
+
+/*
+ *
+ * @author Sebastián Estévez on 10/25/18.
+ *
+ */
+
+
+import com.codahale.metrics.*;
+import com.codahale.metrics.Timer;
+import com.mitchtalmadge.asciidata.graph.ASCIIGraph;
+
+import java.util.*;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class ChartReporter extends ScheduledReporter {
+
+    Map<String, ArrayList<Double>> p99sOverTime = new HashMap<>();
+
+    public ChartReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit) {
+        super(registry, name, filter, rateUnit, durationUnit);
+    }
+
+    protected ChartReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit, ScheduledExecutorService executor) {
+        super(registry, name, filter, rateUnit, durationUnit, executor);
+    }
+
+    protected ChartReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit, ScheduledExecutorService executor, boolean shutdownExecutorOnStop) {
+        super(registry, name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop);
+    }
+
+    protected ChartReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit, ScheduledExecutorService executor, boolean shutdownExecutorOnStop, Set<MetricAttribute> disabledMetricAttributes) {
+        super(registry, name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop, disabledMetricAttributes);
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters, SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters, SortedMap<String, Timer> timers) {
+        for (String timerKey : timers.keySet()) {
+            Snapshot snapshot = timers.get(timerKey).getSnapshot();
+            ArrayList<Double> p99s = p99sOverTime.get(timerKey);
+            if (p99s == null){
+                p99s = new ArrayList<>();
+            }
+            p99s.add(snapshot.get99thPercentile());
+            p99sOverTime.put(timerKey,p99s);
+        }
+    }
+
+    public void generateChart(){
+        for (Map.Entry<String, ArrayList<Double>> p99KV : p99sOverTime.entrySet()) {
+            System.out.println(String.format("Charting p99 Latencies (in microseconds) for %s:",p99KV.getKey()));
+            double[] p99s = p99KV.getValue().stream().mapToDouble(Double::doubleValue).toArray(); //via method reference
+            System.out.println(ASCIIGraph
+                    .fromSeries(p99s)
+                    .withNumRows(8)
+                    .plot());
+        }
+    }
+}

--- a/eb-cli/src/main/java/io/engineblock/cli/EBCLI.java
+++ b/eb-cli/src/main/java/io/engineblock/cli/EBCLI.java
@@ -148,6 +148,13 @@ public class EBCLI {
             System.exit(0);
         }
 
+        if (!options.wantsDisableChart()){
+            logger.info("Charting enabled");
+            scenario.enableCharting();
+        } else{
+            logger.info("Charting disabled");
+        }
+
         scenario.addScenarioScriptParams(scriptData.getScriptParams());
         scenario.addScriptText(scriptData.getScriptTextIgnoringParams());
         ScenarioLogger sl = new ScenarioLogger(scenario)

--- a/eb-cli/src/main/java/io/engineblock/cli/EBCLIOptions.java
+++ b/eb-cli/src/main/java/io/engineblock/cli/EBCLIOptions.java
@@ -61,6 +61,7 @@ public class EBCLIOptions {
     private static final String LOG_STATS = "--log-histostats";
     private static final String CLASSIC_HISTOS = "--classic-histograms";
     private final static String LOG_LEVEL_OVERRIDE = "--log-level-override";
+    private final static String DISABLE_CHART = "--disable-chart";
 
     private static final Set<String> reserved_words = new HashSet<String>() {{
         addAll(
@@ -99,6 +100,7 @@ public class EBCLIOptions {
     private String consoleLoggingPattern = DEFAULT_CONSOLE_LOGGING_PATTERN;
     private String logsLevel = "INFO";
     private Map<String,Level> logLevelsOverrides = new HashMap<>();
+    private boolean disableChart = false;
 
     EBCLIOptions(String[] args) {
         parse(args);
@@ -198,6 +200,10 @@ public class EBCLIOptions {
                 case ADVANCED_HELP:
                     arglist.removeFirst();
                     wantsAdvancedHelp = true;
+                    break;
+                case DISABLE_CHART:
+                    arglist.removeFirst();
+                    disableChart = true;
                     break;
                 case HELP:
                 case "-h":
@@ -354,6 +360,10 @@ public class EBCLIOptions {
 
     public boolean wantsAdvancedHelp() {
         return wantsAdvancedHelp;
+    }
+
+    public boolean wantsDisableChart() {
+        return disableChart;
     }
 
     public int getReportInterval() {

--- a/eb-core/src/main/java/io/engineblock/core/ScenarioResult.java
+++ b/eb-core/src/main/java/io/engineblock/core/ScenarioResult.java
@@ -21,6 +21,7 @@ package io.engineblock.core;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.Slf4jReporter;
 import io.engineblock.metrics.ActivityMetrics;
+import io.engineblock.metrics.ChartReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,9 +35,11 @@ public class ScenarioResult {
     private Exception exception;
     private String iolog;
     private String report;
+    private ChartReporter chartReporter;
 
-    public ScenarioResult(String iolog) {
+    public ScenarioResult(String iolog, ChartReporter chartReporter) {
         this.iolog = iolog;
+        this.chartReporter = chartReporter;
     }
 
     public ScenarioResult(Exception e) {
@@ -53,6 +56,11 @@ public class ScenarioResult {
                 .outputTo(logger)
                 .build();
         reporter.report();
+
+        if (chartReporter != null) {
+            chartReporter.generateChart();
+        }
+
         logger.info("-- END METRICS DETAIL --");
 
     }


### PR DESCRIPTION
This patch is take 1 of our cli charting functionality and it uses the following library:
https://github.com/MitchTalmadge/ASCII-Data

It is on by default (on a 1 second interval) but I included a way to turn it off using `--disable-chart`

```
SLF4J: Actual binding is of type [ch.qos.logback.classic.util.ContextSelectorStaticBinder]
19:18:48.628 [main] INFO  io.engineblock.cli.EBCLI - console logging level is DEBUG
19:18:48.641 [main] WARN  io.engineblock.cli.EBCLIOptions - Console is already logging info or more, so progress data on console is suppressed.
19:18:48.645 [main] DEBUG i.e.activityimpl.ActivityDef - parsed activityDef type=diag;cycles=1E4;cyclerate=1000,1.1; to-> ActivityDef:(0)/{cyclerate=1000,1.1, cycles=1E4, type=diag}
19:18:48.645 [main] INFO  io.engineblock.cli.EBCLI - Charting enabled
Logging to logs/scenario_20181025_191848_621.log
19:18:48.906 [scenarios:001] INFO  io.engineblock.script.Scenario - Running control script for scenario_20181025_191848_621.
19:18:48.907 [scenarios:001] INFO  io.engineblock.script.Scenario - Using direct script compilation
19:18:49.043 [scenarios:001] INFO  i.e.util.SimpleServiceLoader - Loaded Types:[diag, stdout, tcpserver, tcpclient]
19:18:49.050 [scenarios:001] INFO  i.e.util.SimpleServiceLoader - Loaded Types:[cyclelog, targetrate]
19:18:49.057 [scenarios:001] INFO  io.engineblock.core.ActivityExecutor - starting activity ALIAS_UNSET for cycles [0..10000)=10000
19:18:49.066 [scenarios:001] INFO  i.e.activityapi.rates.RateLimiters - Using rate limiter: spec=[cycle]:rate=1,000 burstRatio=1.100 (1,000 SOPSS 1,100 BOPSS)
  (⏲, ∑running)=(2125719, 0.002134S) (alloc sched)=(0 0) (getwait get∑wait)=(0.002 0.002)
19:18:49.123 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=0, phase=0, report delay=30ms
19:18:49.123 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action   modulo, input=0, phase=0
19:18:49.150 [scenarios:001] INFO  io.engineblock.core.ActivityExecutor - Stopping executor for ALIAS_UNSET when work completes.
19:18:50.098 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=1009, phase=0, report delay=5ms
19:18:51.577 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=2513, phase=0, report delay=484ms
19:18:52.580 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=3516, phase=0, report delay=487ms
19:18:53.583 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=4519, phase=0, report delay=490ms
19:18:54.585 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=5521, phase=0, report delay=492ms
19:18:55.588 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=6524, phase=0, report delay=495ms
19:18:56.590 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=7526, phase=0, report delay=497ms
19:18:57.592 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=8528, phase=0, report delay=498ms
19:18:58.094 [ALIAS_UNSET:001] INFO  i.e.activities.diag.DiagAction - diag action interval, input=9136, phase=0, report delay=1ms
19:18:58.598 [scenarios:001] INFO  io.engineblock.script.Scenario - Awaiting completion of scenario for 1471228928 millis.
19:18:58.600 [scenarios:001] INFO  io.engineblock.core.ActivityExecutor - Stopping executor for ALIAS_UNSET when work completes.
19:18:58.606 [main] INFO  i.e.script.ScenariosExecutor - scenarios executor shutdownActivity after 9947ms.
19:18:58.609 [main] INFO  io.engineblock.core.ScenariosResults - results for scenario: name:'scenario_20181025_191848_621'
19:18:58.610 [main] INFO  io.engineblock.core.ScenarioResult - -- BEGIN METRICS DETAIL --
19:18:58.618 [main] INFO  io.engineblock.core.ScenarioResult - type=GAUGE, name=ALIAS_UNSET.cycle.config_burstrate, value=1100.0
19:18:58.621 [main] INFO  io.engineblock.core.ScenarioResult - type=GAUGE, name=ALIAS_UNSET.cycle.config_cyclerate, value=1000.0
19:18:58.622 [main] INFO  io.engineblock.core.ScenarioResult - type=GAUGE, name=ALIAS_UNSET.cycle.waittime, value=0
19:18:58.627 [main] INFO  io.engineblock.core.ScenarioResult - type=HISTOGRAM, name=ALIAS_UNSET.delay, count=10, min=1, max=498, mean=347.9, stddev=220.04747215089748, median=487.0, p75=495.0, p95=498.0, p98=498.0, p99=498.0, p999=498.0
19:18:58.742 [main] INFO  io.engineblock.core.ScenarioResult - type=TIMER, name=ALIAS_UNSET.cycles, count=10000, min=1.394, max=678.111, mean=2.224234809474768, stddev=21.727119812092088, median=1.439, p75=1.501, p95=1.574, p98=2.05, p99=2.393, p999=678.111, mean_rate=1037.8136282241571, m1=1104.2, m5=1104.2, m15=1104.2, rate_unit=events/second, duration_unit=microseconds
19:18:58.766 [main] INFO  io.engineblock.core.ScenarioResult - type=TIMER, name=ALIAS_UNSET.phases, count=10000, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=1035.361328471193, m1=1104.2, m5=1104.2, m15=1104.2, rate_unit=events/second, duration_unit=microseconds
19:18:58.780 [main] INFO  io.engineblock.core.ScenarioResult - type=TIMER, name=ALIAS_UNSET.read_input, count=10001, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=1034.6398129409952, m1=1104.3999999999999, m5=1104.3999999999999, m15=1104.3999999999999, rate_unit=events/second, duration_unit=microseconds
19:18:58.812 [main] INFO  io.engineblock.core.ScenarioResult - type=TIMER, name=ALIAS_UNSET.strides, count=10000, min=0.0, max=0.0, mean=0.0, stddev=0.0, median=0.0, p75=0.0, p95=0.0, p98=0.0, p99=0.0, p999=0.0, mean_rate=1030.66939342609, m1=1104.2, m5=1104.2, m15=1104.2, rate_unit=events/second, duration_unit=microseconds
Charting p99 Latencies (in microseconds) for ALIAS_UNSET.cycles:
80306175.┼╮        
68833864.┤│        
57361553.┤│        
45889242.┤│        
34416932.┤│        
22944621.┤╰╮       
11472310.┤1│       
    0.00 ┼ ╰───────

Charting p99 Latencies (in microseconds) for ALIAS_UNSET.strides:
53735.00 ┼╮        
46659.00 ┤│        
39583.00 ┤│        
32507.00 ┤╰╮       
25431.00 ┤ │       
18355.00 ┤ │  ╭╮   
11279.00 ┤ ╰╮╭╯│   
 4203.00 ┤  ╰╯ ╰───

Charting p99 Latencies (in microseconds) for ALIAS_UNSET.read_input:
 8551.00 ┼╮        
 7394.43 ┤│        
 6237.86 ┤│        
 5081.29 ┤│        
 3924.71 ┤╰╮       
 2768.14 ┤ ╰╮      
 1611.57 ┤  │      
  455.00 ┤  ╰──────

Charting p99 Latencies (in microseconds) for ALIAS_UNSET.phases:
 4173.00 ┼╮        
 3644.86 ┤│        
 3116.71 ┤│        
 2588.57 ┤│        
 2060.43 ┤│        
 1532.29 ┤│        
 1004.14 ┤╰╮╭─╮╭╮  
  476.00 ┤ ╰╯ ╰╯╰──
```