### PR TITLE
Anchor-reuse

### DIFF
--- a/eb-api/src/main/java/activityconfig/ParsedStmt.java
+++ b/eb-api/src/main/java/activityconfig/ParsedStmt.java
@@ -82,7 +82,12 @@ public class ParsedStmt {
             spans.add(pre);
 
             if (extraBindings.contains(tokenName)) {
-                specificBindings.put(tokenName, stmtDef.getBindings().get(tokenName));
+                if (specificBindings.get(tokenName) != null){
+                    String postfix = UUID.randomUUID().toString();
+                    specificBindings.put(tokenName+postfix, stmtDef.getBindings().get(tokenName));
+                }else {
+                    specificBindings.put(tokenName, stmtDef.getBindings().get(tokenName));
+                }
             } else {
                 missingBindings.add(tokenName);
             }

--- a/eb-api/src/test/java/activityconfig/yaml/ParsedStmtTest.java
+++ b/eb-api/src/test/java/activityconfig/yaml/ParsedStmtTest.java
@@ -80,7 +80,11 @@ public class ParsedStmtTest {
         ParsedStmt parsed1 = stmtDef1.getParsed();
         assertThat(parsed1.getMissingBindings().isEmpty());
         assertThat(parsed1.hasError()).isFalse();
-        assertThat(parsed1.getSpecificBindings()).containsOnlyKeys("alpha");
+        assertThat(parsed1.getSpecificBindings().size() == 2);
+        assertThat(parsed1.getSpecificBindings().containsKey("alpha"));
+        for (String key: parsed1.getSpecificBindings().keySet()) {
+            assertThat(key.startsWith("alpha"));
+        }
 
     }
 


### PR DESCRIPTION
In `ParsedStmt.parse()` I'm appending a `UUID` to the binding name if it already appears in specificBindings. This makes it so that binding names can get reused.